### PR TITLE
Fix delta time update for robot movement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -352,20 +352,21 @@ document.addEventListener('DOMContentLoaded', () => {
   engine.runRenderLoop(() => {
     const currentTime = Date.now();
     const deltaTime = currentTime - lastUpdateTime;
+    lastUpdateTime = currentTime;
 
     // Update robots every frame
-    robots.forEach(robot => {
-      robot = updateRobotMovement(robot, maze, deltaTime / 1000);
+    robots.forEach((robot, i) => {
+      const updated = updateRobotMovement(robot, maze, deltaTime / 1000);
+      robots[i] = updated;
       // Update robot mesh position with interpolation
-      if (robot.mesh) {
-        const { x: currentX, y: currentY } = robot.currentTile;
-        const { x: targetX, y: targetY } = robot.targetTile;
+      if (updated.mesh) {
+        const { x: currentX, y: currentY } = updated.currentTile;
+        const { x: targetX, y: targetY } = updated.targetTile;
         
         // Interpolate between current and target position based on progress
-        const interpolatedX = currentX + (targetX - currentX) * robot.progress;
-        const interpolatedY = currentY + (targetY - currentY) * robot.progress;
-        
-        robot.mesh.position = new Vector3(interpolatedX + 0.5, 0.5, interpolatedY + 0.5);
+        const interpolatedX = currentX + (targetX - currentX) * updated.progress;
+        const interpolatedY = currentY + (targetY - currentY) * updated.progress;
+        updated.mesh.position = new Vector3(interpolatedX + 0.5, 0.5, interpolatedY + 0.5);
       }
     });
 

--- a/src/robot/robot.ts
+++ b/src/robot/robot.ts
@@ -57,8 +57,11 @@ export function updateRobotMovement(robot: Robot, maze: Maze, deltaTime: number)
 
     // If current direction is valid, keep it
     if (testX >= 0 && testX < width && testY >= 0 && testY < height && maze.grid[testY][testX] !== 'wall') {
-      robot.targetTile = { x: testX, y: testY };
-      return robot;
+      return {
+        ...robot,
+        targetTile: { x: testX, y: testY },
+        progress,
+      };
     }
 
     // If current direction is not valid, try other directions
@@ -75,9 +78,12 @@ export function updateRobotMovement(robot: Robot, maze: Maze, deltaTime: number)
       }
 
       if (testX >= 0 && testX < width && testY >= 0 && testY < height && maze.grid[testY][testX] !== 'wall') {
-        robot.direction = dir;
-        robot.targetTile = { x: testX, y: testY };
-        return robot;
+        return {
+          ...robot,
+          direction: dir,
+          targetTile: { x: testX, y: testY },
+          progress,
+        };
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix delta time calculation in main render loop
- return new robot state with updated progress to prevent stalls
- update robot array with updated robots so movement persists

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@babylonjs/core')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ddd85b668833286c43e896d748936