### PR TITLE
Add Codex setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ All project documentation is located in the [docs](docs/) directory:
 
 ## Getting Started
 
-1. Install dependencies:
+1. Install dependencies. In most environments, run:
    ```bash
    npm install
+   ```
+   If you are running inside a Codex sandbox, first ensure network access is
+   enabled and execute the setup script:
+   ```bash
+   scripts/setup-codex.sh
    ```
 
 2. Start the development server:

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,9 +18,13 @@ See `requirements.md` for the full design spec.
    git clone <repo-url>
    cd shark-robot-maze
    ```
-2. Install dependencies:
+2. Install dependencies. Normally run:
    ```sh
    npm install
+   ```
+   In the Codex sandbox, ensure networking is enabled and run:
+   ```sh
+   scripts/setup-codex.sh
    ```
 3. Run the development server:
    ```sh

--- a/scripts/setup-codex.sh
+++ b/scripts/setup-codex.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Set up project dependencies for Codex environment.
+# Requires root privileges and internet access.
+set -e
+
+# Optionally install Node.js if missing.
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Installing Node.js..."
+  apt-get update
+  apt-get install -y nodejs npm
+fi
+
+# Install npm dependencies
+npm install


### PR DESCRIPTION
## Summary
- add a setup script for Codex environments
- document how to use the new script in README and docs

## Testing
- `npm test` *(fails: `jest` not found)*
- `npm run lint` *(fails: ESLint config not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684de2ea6e6c83329f1d508ef2c13bbd