### PR TITLE
Fix idle robot progress accumulation

### DIFF
--- a/src/robots/robot.ts
+++ b/src/robots/robot.ts
@@ -98,7 +98,8 @@ export function updateRobotMovement(robot: Robot, maze: Maze, player: { x: numbe
       }
     }
   } else {
-    progress += speed * dt;
+    // Remain idle without accumulating progress
+    progress = 0;
     if (progress >= 1) {
       // Snap to target tile
       const newCurrentTile = { ...robot.targetTile };

--- a/tests/robot_idle.test.ts
+++ b/tests/robot_idle.test.ts
@@ -1,0 +1,29 @@
+import { updateRobotMovement, RobotBehavior, Robot } from '../src/robots/robot';
+import { createSimpleMaze } from '../src/maze/maze';
+
+describe('Robot idle behavior', () => {
+  it('does not accumulate progress when stationary', () => {
+    const maze = createSimpleMaze();
+    const robot: Robot = {
+      id: 1,
+      currentTile: { x: 1, y: 1 },
+      targetTile: { x: 1, y: 1 },
+      progress: 0,
+      direction: 'right',
+      behavior: RobotBehavior.PATROL,
+      chaseTarget: null,
+      mesh: null,
+      isProtected: true,
+      spawnArea: { x: 1, y: 1 }
+    };
+    const player = { x: 0, y: 0 };
+    const dt = 0.5;
+    const speed = 1;
+
+    let updated = updateRobotMovement(robot, maze, player, dt, speed);
+    expect(updated.progress).toBe(0);
+
+    updated = updateRobotMovement(updated, maze, player, dt, speed);
+    expect(updated.progress).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent idle robots from incrementing progress
- test that robots don't accumulate progress while stationary

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de55727e48332ac00c156139122d5